### PR TITLE
Set monospace font for runner UI

### DIFF
--- a/fujielab/util/launcher/script_runner.py
+++ b/fujielab/util/launcher/script_runner.py
@@ -1,5 +1,6 @@
 from PyQt5.QtWidgets import QWidget, QTextEdit, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFormLayout, QVBoxLayout, QSizePolicy, QDialog, QComboBox, QFileDialog, QGridLayout
 from PyQt5.QtCore import QProcess, Qt
+from PyQt5.QtGui import QFontDatabase
 import subprocess
 import json
 from pathlib import Path
@@ -21,6 +22,8 @@ class ScriptRunnerWidget(QWidget):
         self.stderr_buffer = ""
         self.output_view = QTextEdit()
         self.output_view.setReadOnly(True)
+        fixed_font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        self.output_view.setFont(fixed_font)
         self.interpreter_label = QLabel("インタプリタ:")
         self.script_label = QLabel("スクリプト:")
         self.dir_label = QLabel("作業ディレクトリ:")
@@ -76,6 +79,7 @@ class ScriptRunnerWidget(QWidget):
         self.input_line = QLineEdit()
         self.input_line.setPlaceholderText("標準入力をここに入力しEnterで送信")
         self.input_line.setFixedHeight(22)
+        self.input_line.setFont(fixed_font)
         self.input_line.returnPressed.connect(self.send_stdin)
         layout.addWidget(self.input_line)
         self.setLayout(layout)

--- a/fujielab/util/launcher/shell_runner.py
+++ b/fujielab/util/launcher/shell_runner.py
@@ -1,5 +1,6 @@
 from PyQt5.QtWidgets import QWidget, QTextEdit, QLabel, QLineEdit, QPushButton, QHBoxLayout, QFormLayout, QVBoxLayout, QSizePolicy, QFileDialog, QGridLayout
 from PyQt5.QtCore import QProcess
+from PyQt5.QtGui import QFontDatabase
 import platform
 from pathlib import Path
 from .shell_settings_dialog import ShellSettingsDialog
@@ -13,6 +14,8 @@ class ShellRunnerWidget(QWidget):
         self.working_dir = ""
         self.output_view = QTextEdit()
         self.output_view.setReadOnly(True)
+        fixed_font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        self.output_view.setFont(fixed_font)
         self.program_label = QLabel("コマンドライン:")
         self.dir_label = QLabel("作業ディレクトリ:")
         self.program_value = QLineEdit()
@@ -54,6 +57,7 @@ class ShellRunnerWidget(QWidget):
         self.input_line = QLineEdit()
         self.input_line.setPlaceholderText("標準入力をここに入力しEnterで送信")
         self.input_line.setFixedHeight(22)
+        self.input_line.setFont(fixed_font)
         self.input_line.returnPressed.connect(self.send_stdin)
         layout.addWidget(self.input_line)
         self.setLayout(layout)


### PR DESCRIPTION
## Summary
- set output and input fonts to a fixed-width font in runner widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b80c4d2c832f8259591da8827077