### PR TITLE
Add args option for Python launcher

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -49,6 +49,7 @@ fujielab-launcher --config /path/to/your/custom_config.yaml
 
 - 設定可能な複数プログラムランチャー
 - Pythonスクリプトやシェルコマンドのサポート
+- Pythonスクリプトにコマンドライン引数を渡す機能
 - カスタマイズ可能なワークスペースディレクトリ設定
 - クロスプラットフォーム対応（Windows、macOS、Linux）
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This is useful for switching between different configuration profiles or importi
 
 - Multiple program launcher with configurable settings
 - Support for Python scripts and shell commands
+- Ability to pass command line arguments to Python scripts
 - Customizable workspace directory settings
 - Cross-platform support (Windows, macOS, Linux)
 

--- a/fujielab/util/launcher/i18n.py
+++ b/fujielab/util/launcher/i18n.py
@@ -61,6 +61,7 @@ _translations = {
         'Select directory': 'ディレクトリ選択',
         'Interpreter': 'インタプリタ',
         'Command line:': 'コマンドライン:',
+        'Arguments:': '引数:',
         'Main Menu': 'メインメニュー',
         'Select script': 'スクリプトを選択',
         'Select executable file': '実行ファイルを選択',


### PR DESCRIPTION
## Summary
- enable command-line arguments for Python launcher
- translate `Arguments:` label
- document new ability in both English and Japanese READMEs

## Testing
- `python -m compileall -q fujielab/util/launcher`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685224260ef0832fb0c29666effa1af8