### PR TITLE
Improve UI state handling for launcher widgets

### DIFF
--- a/fujielab/util/launcher/script_runner.py
+++ b/fujielab/util/launcher/script_runner.py
@@ -142,6 +142,9 @@ class ScriptRunnerWidget(QWidget):
         self.dir_select_button.clicked.connect(self.select_dir)
         self.args_value.textChanged.connect(self.on_args_changed)
 
+        # 初期状態では実行されていないためUIを更新
+        self.update_ui_state(running=False)
+
     def on_interpreter_changed(self):
         label = self.interpreter_combo.currentText()
         self.interpreter_path = self.interpreter_map.get(label, "python")
@@ -159,6 +162,15 @@ class ScriptRunnerWidget(QWidget):
             self.input_line.clear()
         else:
             self.output_view.append("<span style='color:red;'>プロセスが起動していません</span>")
+
+    def update_ui_state(self, running: bool):
+        """Enable or disable widgets depending on running state."""
+        self.run_button.setEnabled(not running)
+        self.stop_button.setEnabled(running)
+        self.script_select_button.setEnabled(not running)
+        self.dir_select_button.setEnabled(not running)
+        self.interpreter_combo.setEnabled(not running)
+        self.input_line.setEnabled(running)
 
     def get_interpreters(self, force_refresh=False):
         global interpreter_cache
@@ -647,6 +659,7 @@ class ScriptRunnerWidget(QWidget):
         self.output_view.clear()
         self.output_view.append(tr("Starting script..."))
         self.process.start()
+        self.update_ui_state(running=True)
 
     def handle_process_error(self, error):
         self.output_view.append(f"<span style='color:red;'>QProcessエラー: {error}</span>")
@@ -762,6 +775,7 @@ class ScriptRunnerWidget(QWidget):
             self.stderr_buffer = ""
 
         self.output_view.append(tr("Script finished"))
+        self.update_ui_state(running=False)
 
     def select_script(self):
         default_dir = self.working_dir or str(Path.cwd())

--- a/fujielab/util/launcher/shell_runner.py
+++ b/fujielab/util/launcher/shell_runner.py
@@ -80,6 +80,9 @@ class ShellRunnerWidget(QWidget):
         self.setLayout(layout)
         self.config_changed_callback = None
 
+        # プログラムは起動していない状態でUIを初期化
+        self.update_ui_state(running=False)
+
     def on_cmdline_changed(self, text):
         self.program_cmdline = text
         if self.config_changed_callback:
@@ -138,6 +141,15 @@ class ShellRunnerWidget(QWidget):
             self.input_line.clear()
         else:
             self.output_view.append("<span style='color:red;'>プロセスが起動していません</span>")
+
+    def update_ui_state(self, running: bool):
+        """Enable or disable widgets depending on running state."""
+        self.run_button.setEnabled(not running)
+        self.stop_button.setEnabled(running)
+        self.dir_select_button.setEnabled(not running)
+        if self.is_windows:
+            self.exe_select_button.setEnabled(not running)
+        self.input_line.setEnabled(running)
 
     def run_program(self):
         self.output_view.append("[debug] run_program called")
@@ -204,6 +216,7 @@ class ShellRunnerWidget(QWidget):
         self.process.errorOccurred.connect(self.handle_process_error)
         self.output_view.append(tr("Starting program..."))
         self.process.start()
+        self.update_ui_state(running=True)
 
     def handle_process_error(self, error):
         self.output_view.append(f"<span style='color:red;'>QProcessエラー: {error}</span>")
@@ -294,6 +307,7 @@ class ShellRunnerWidget(QWidget):
 
     def process_finished(self):
         self.output_view.append(tr("Program finished"))
+        self.update_ui_state(running=False)
 
     def _parse_exe_command(self, command):
         """コマンドライン文字列をEXEパスと引数に分割する


### PR DESCRIPTION
## Summary
- disable buttons while Python or Shell launchers are running
- reenable them when the process finishes

## Testing
- `pytest -q`
- `cat /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_685368631678832fa60ea437932fcc28